### PR TITLE
Log unhandled exceptions during server startup

### DIFF
--- a/src/server/bnetserver/Main.cpp
+++ b/src/server/bnetserver/Main.cpp
@@ -85,7 +85,9 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
 
 int main(int argc, char** argv)
 {
-    signal(SIGABRT, &Trinity::AbortHandler);
+    try
+    {
+        signal(SIGABRT, &Trinity::AbortHandler);
 
     auto configFile = fs::absolute(_TRINITY_BNET_CONFIG);
     std::string configService;
@@ -249,9 +251,20 @@ int main(int argc, char** argv)
 
     TC_LOG_INFO("server.bnetserver", "Halting process...");
 
-    signals.cancel();
+        signals.cancel();
 
-    return 0;
+        return 0;
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << "bnetserver terminated due to unhandled exception: " << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cerr << "bnetserver terminated due to unknown unhandled exception" << std::endl;
+    }
+
+    return 1;
 }
 
 /// Initialize connection to the database

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -124,7 +124,9 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
 /// Launch the Trinity server
 extern int main(int argc, char** argv)
 {
-    signal(SIGABRT, &Trinity::AbortHandler);
+    try
+    {
+        signal(SIGABRT, &Trinity::AbortHandler);
 
     auto configFile = fs::absolute(_TRINITY_CORE_CONFIG);
     std::string configService;
@@ -415,11 +417,22 @@ extern int main(int argc, char** argv)
 
     TC_LOG_INFO("server.worldserver", "Halting process...");
 
-    // 0 - normal shutdown
-    // 1 - shutdown at error
-    // 2 - restart command used, this code can be used by restarter for restart Trinityd
+        // 0 - normal shutdown
+        // 1 - shutdown at error
+        // 2 - restart command used, this code can be used by restarter for restart Trinityd
 
-    return World::GetExitCode();
+        return World::GetExitCode();
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << "worldserver terminated due to unhandled exception: " << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cerr << "worldserver terminated due to unknown unhandled exception" << std::endl;
+    }
+
+    return 1;
 }
 
 void ShutdownCLIThread(std::thread* cliThread)


### PR DESCRIPTION
## Summary
- catch and report unexpected exceptions in `worldserver` startup
- catch and report unexpected exceptions in `bnetserver` startup

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by "boost_filesystem")*


------
https://chatgpt.com/codex/tasks/task_e_689899214e90832eb2a3c10d49fb7e67